### PR TITLE
Add function to remove tags after processing

### DIFF
--- a/ekphrasis/utils/helpers.py
+++ b/ekphrasis/utils/helpers.py
@@ -96,4 +96,11 @@ def product(nums):
     """
     return reduce(operator.mul, nums, 1)
 
+def remove_tags(doc):
+    """
+    Remove tags from sentence
+    """
+    doc = ' '.join(word for word in doc.split() if word[0]!='<')
+    return doc
+
 # check_stats_files()


### PR DESCRIPTION
## Description 

Just added a small function to remove tags after annotation and/or normalization. I wanted to have the sentences return without having the tags for further processing. For example after fixing an elongated word. Not the ideal solution but it gets the job done.

* Added  function remove_tags in helpers.py
* Added function call from the preprocessor

## To do

* Test function remove_tags
*  Code needs linting 