### PR TITLE
if the hashtag or word is in all caps, lower it

### DIFF
--- a/ekphrasis/classes/preprocessor.py
+++ b/ekphrasis/classes/preprocessor.py
@@ -7,7 +7,7 @@ from ekphrasis.classes.exmanager import ExManager
 from ekphrasis.classes.segmenter import Segmenter
 from ekphrasis.classes.spellcorrect import SpellCorrector
 from ekphrasis.utils.nlp import unpack_contractions
-
+from ekphrasis.utils.helpers import remove_tags
 
 # noinspection PyPackageRequirements
 class TextPreProcessor:
@@ -72,6 +72,8 @@ class TextPreProcessor:
 
             fix_text (bool): choose if you want to fix bad unicode terms and
                 html entities.
+            
+            remove_tags (bool): Choose to remove tags after processing
         """
         self.omit = kwargs.get("omit", {})
         self.backoff = kwargs.get("normalize", {})
@@ -87,6 +89,7 @@ class TextPreProcessor:
         self.corrector_corpus = kwargs.get("corrector", "english")
         self.all_caps_tag = kwargs.get("all_caps_tag", "wrap")
         self.mode = kwargs.get("mode", "normal")
+        self.remove_tags = kwargs.get("remove_tags", False)
 
         if self.unpack_hashtags:
             self.segmenter = Segmenter(corpus=self.segmenter_corpus)
@@ -153,10 +156,8 @@ class TextPreProcessor:
 
     def handle_elongated_match(self, m):
         text = m.group()
-
         # normalize to at most 2 repeating chars
         text = self.regexes["normalize_elong"].sub(r'\1\1', text)
-
         normalized = self.spell_corrector.normalize_elongated(text)
         if normalized:
             text = normalized
@@ -174,6 +175,7 @@ class TextPreProcessor:
             text = self.add_special_tag(text, "elongated")
 
         return text
+    
 
     @lru_cache(maxsize=65536)
     def handle_repeated_puncts(self, m):
@@ -307,7 +309,7 @@ class TextPreProcessor:
             if "censored" in self.include_tags:
                 doc = self.regexes["censored"].sub(
                     lambda w: self.handle_generic_match(w, "censored"), doc)
-
+        
         ###########################
         # unpack contractions: i'm -> i am, can't -> can not...
         ###########################
@@ -316,6 +318,9 @@ class TextPreProcessor:
         if self.unpack_contractions:
             doc = unpack_contractions(doc)
 
+        if self.remove_tags:
+            doc = remove_tags(doc)
+     
         # omit allcaps if inside hashtags
         doc = re.sub(r' +', ' ', doc)  # remove repeating spaces
         # doc = re.sub(r'<hashtag><allcaps>', '<hashtag>', doc)  # remove repeating spaces

--- a/ekphrasis/classes/segmenter.py
+++ b/ekphrasis/classes/segmenter.py
@@ -131,7 +131,7 @@ class Segmenter:
     # if you don't have enough RAM lower the maxsize
     @lru_cache(maxsize=65536)
     def segment(self, word):
-        if word.isupper():
+        if word.isupper() or (word[0].isupper() and word[1:].islower()):
             word = word.lower()
         if word.islower():
             return " ".join(self.find_segment(word)[1])

--- a/ekphrasis/classes/segmenter.py
+++ b/ekphrasis/classes/segmenter.py
@@ -131,6 +131,8 @@ class Segmenter:
     # if you don't have enough RAM lower the maxsize
     @lru_cache(maxsize=65536)
     def segment(self, word):
+        if word.isupper():
+            word = word.lower()
         if word.islower():
             return " ".join(self.find_segment(word)[1])
         else:

--- a/ekphrasis/tools/generate_stats.py
+++ b/ekphrasis/tools/generate_stats.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 import numpy
 from tqdm import tqdm
 
-REGEX_TOKEN = re.compile(r'(?<![#@])\b[a-z]{1,15}\b')
+REGEX_TOKEN = re.compile(r'(?<![#@])\b[a-z\u00C0-\u00FF0-9]{1,15}\b')
 REGEX_URL = re.compile(
     r"(https?:\/\/(?:www\.|(?!www))[^\s\.]+\.[^\s]{2,}|www\.[^\s]+\.[^\s]{2,})")
 SEPARATOR = "_"


### PR DESCRIPTION
Example: "IMUSTGO" to "imustgo"
Allows the current segmenter to split hashtags that are in all caps.