### PR TITLE
Allow unpack_contractions to check for ’

### DIFF
--- a/ekphrasis/utils/nlp.py
+++ b/ekphrasis/utils/nlp.py
@@ -42,23 +42,23 @@ def unpack_contractions(text):
     """
     # standard
     text = re.sub(
-        r"(\b)([Aa]re|[Cc]ould|[Dd]id|[Dd]oes|[Dd]o|[Hh]ad|[Hh]as|[Hh]ave|[Ii]s|[Mm]ight|[Mm]ust|[Ss]hould|[Ww]ere|[Ww]ould)n['‘]t",
+        r"(\b)([Aa]re|[Cc]ould|[Dd]id|[Dd]oes|[Dd]o|[Hh]ad|[Hh]as|[Hh]ave|[Ii]s|[Mm]ight|[Mm]ust|[Ss]hould|[Ww]ere|[Ww]ould)n['’]t",
         r"\1\2 not", text)
     text = re.sub(
-        r"(\b)([Hh]e|[Ii]|[Ss]he|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)['‘]ll",
+        r"(\b)([Hh]e|[Ii]|[Ss]he|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)['’]ll",
         r"\1\2 will", text)
-    text = re.sub(r"(\b)([Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)['‘]re", r"\1\2 are",
+    text = re.sub(r"(\b)([Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)['’]re", r"\1\2 are",
                   text)
     text = re.sub(
-        r"(\b)([Ii]|[Ss]hould|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Ww]ould|[Yy]ou)['‘]ve",
+        r"(\b)([Ii]|[Ss]hould|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Ww]ould|[Yy]ou)['’]ve",
         r"\1\2 have", text)
     # non-standard
-    text = re.sub(r"(\b)([Cc]a)n['‘]t", r"\1\2n not", text)
-    text = re.sub(r"(\b)([Ii])['‘]m", r"\1\2 am", text)
-    text = re.sub(r"(\b)([Ll]et)['‘]s", r"\1\2 us", text)
-    text = re.sub(r"(\b)([Ww])on['‘]t", r"\1\2ill not", text)
-    text = re.sub(r"(\b)([Ss])han['‘]t", r"\1\2hall not", text)
-    text = re.sub(r"(\b)([Yy])(?:['‘]all|a['‘]ll)", r"\1\2ou all", text)
+    text = re.sub(r"(\b)([Cc]a)n['’]t", r"\1\2n not", text)
+    text = re.sub(r"(\b)([Ii])['’]m", r"\1\2 am", text)
+    text = re.sub(r"(\b)([Ll]et)['’]s", r"\1\2 us", text)
+    text = re.sub(r"(\b)([Ww])on['’]t", r"\1\2ill not", text)
+    text = re.sub(r"(\b)([Ss])han['’]t", r"\1\2hall not", text)
+    text = re.sub(r"(\b)([Yy])(?:['’]all|a['’]ll)", r"\1\2ou all", text)
     return text
 
 

--- a/ekphrasis/utils/nlp.py
+++ b/ekphrasis/utils/nlp.py
@@ -42,23 +42,23 @@ def unpack_contractions(text):
     """
     # standard
     text = re.sub(
-        r"(\b)([Aa]re|[Cc]ould|[Dd]id|[Dd]oes|[Dd]o|[Hh]ad|[Hh]as|[Hh]ave|[Ii]s|[Mm]ight|[Mm]ust|[Ss]hould|[Ww]ere|[Ww]ould)n't",
+        r"(\b)([Aa]re|[Cc]ould|[Dd]id|[Dd]oes|[Dd]o|[Hh]ad|[Hh]as|[Hh]ave|[Ii]s|[Mm]ight|[Mm]ust|[Ss]hould|[Ww]ere|[Ww]ould)n['‘]t",
         r"\1\2 not", text)
     text = re.sub(
-        r"(\b)([Hh]e|[Ii]|[Ss]he|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)'ll",
+        r"(\b)([Hh]e|[Ii]|[Ss]he|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)['‘]ll",
         r"\1\2 will", text)
-    text = re.sub(r"(\b)([Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)'re", r"\1\2 are",
+    text = re.sub(r"(\b)([Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Yy]ou)['‘]re", r"\1\2 are",
                   text)
     text = re.sub(
-        r"(\b)([Ii]|[Ss]hould|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Ww]ould|[Yy]ou)'ve",
+        r"(\b)([Ii]|[Ss]hould|[Tt]hey|[Ww]e|[Ww]hat|[Ww]ho|[Ww]ould|[Yy]ou)['‘]ve",
         r"\1\2 have", text)
     # non-standard
-    text = re.sub(r"(\b)([Cc]a)n't", r"\1\2n not", text)
-    text = re.sub(r"(\b)([Ii])'m", r"\1\2 am", text)
-    text = re.sub(r"(\b)([Ll]et)'s", r"\1\2 us", text)
-    text = re.sub(r"(\b)([Ww])on't", r"\1\2ill not", text)
-    text = re.sub(r"(\b)([Ss])han't", r"\1\2hall not", text)
-    text = re.sub(r"(\b)([Yy])(?:'all|a'll)", r"\1\2ou all", text)
+    text = re.sub(r"(\b)([Cc]a)n['‘]t", r"\1\2n not", text)
+    text = re.sub(r"(\b)([Ii])['‘]m", r"\1\2 am", text)
+    text = re.sub(r"(\b)([Ll]et)['‘]s", r"\1\2 us", text)
+    text = re.sub(r"(\b)([Ww])on['‘]t", r"\1\2ill not", text)
+    text = re.sub(r"(\b)([Ss])han['‘]t", r"\1\2hall not", text)
+    text = re.sub(r"(\b)([Yy])(?:['‘]all|a['‘]ll)", r"\1\2ou all", text)
     return text
 
 


### PR DESCRIPTION
Right now unpack_contractions check for ' e.g.  you're. But sometime in text, ’ is used instead of ' e.g. you’re. This PR should would allow checking for both cases.